### PR TITLE
Test and fix for the case that both header + remote address are trusted

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,9 @@ func (t *TrustedProxies) filterOutIPsFromUntrustedSources(remoteAddr net.IP, hea
 		rv = append(rv, ip)
 		if t.IsIPTrusted(ip) != nil {
 			idx--
+			if idx < 0 {
+				break
+			}
 		} else {
 			// If we come across an IP that isn't trusted, we stop processing
 			break

--- a/main_test.go
+++ b/main_test.go
@@ -179,6 +179,14 @@ func TestTrustedProxies_DeduceClientIP(t *testing.T) {
 			[]string{"30.30.30.30"},
 			args{net.ParseIP("10.10.10.10"), "30.30.30.30, 20.20.20.20"},
 			"10.10.10.10"},
+		{"Single IP in header, all IPs trusted",
+			[]string{"30.30.30.30", "10.10.10.10"},
+			args{net.ParseIP("10.10.10.10"), "30.30.30.30"},
+			"30.30.30.30"},
+		{"Remote address is same as in header, trusted",
+			[]string{"30.30.30.30"},
+			args{net.ParseIP("30.30.30.30"), "30.30.30.30"},
+			"30.30.30.30"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
this would lead to a runtime error previously ("index out of range")